### PR TITLE
FI-4182: Update gemspec: remove email and set authors to Inferno Team

### DIFF
--- a/cancer_registry_reporting_test_kit.gemspec
+++ b/cancer_registry_reporting_test_kit.gemspec
@@ -5,8 +5,7 @@ require_relative 'lib/cancer_registry_reporting_test_kit/version'
 Gem::Specification.new do |spec|
   spec.name          = 'cancer_registry_reporting_test_kit'
   spec.version       = CancerRegistryReportingTestKit::VERSION
-  spec.authors       = ['Diego Griese', 'Christine Duong', 'David Clark', 'Zachary Robin', 'Nate Cady', 'Robert Passas', 'Karl Naden']
-  spec.email         = ['inferno@groups.mitre.org']
+  spec.authors       = ['Inferno Team']
   spec.summary       = 'Central Cancer Registry Reporting Test Kit'
   spec.description   = 'Inferno test kit for testing systems per the Central Cancer Registry Reporting IG'
   spec.homepage      = 'https://github.com/inferno-framework/cancer-registry-reporting-test-kit'


### PR DESCRIPTION
Email isn't required for gemspec, according to the spec: https://guides.rubygems.org/specification-reference/

Also updated the authors to be more generic.

