### PR TITLE
Fix Docker execution and session creation

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,2 +1,3 @@
 REDIS_URL=redis://redis:6379/0
+INFERNO_HOST=http://localhost
 FHIR_RESOURCE_VALIDATOR_URL=http://hl7_validator_service:3500

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR $INSTALL_PATH
 
 ADD *.gemspec $INSTALL_PATH
 ADD Gemfile* $INSTALL_PATH
+ADD lib/cancer_registry_reporting_test_kit/version.rb $INSTALL_PATH/lib/cancer_registry_reporting_test_kit/version.rb
 RUN gem install bundler
 # The below RUN line is commented out for development purposes, because any change to the
 # required gems will break the dockerfile build process.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     volumes:
       - ./data:/opt/inferno/data
     depends_on:
-      - validator_service
+      - hl7_validator_service
   worker:
     build:
       context: ./


### PR DESCRIPTION
# Summary

Previously, when this test kit could not be [run locally in docker](https://inferno-framework.github.io/docs/getting-started-users.html#running-an-existing-test-kit). Now, docker execution works and users are correctly redirected to the main Inferno UI when a session is created.

# Testing Guidance

1. Start the test kit [using docker](https://inferno-framework.github.io/docs/getting-started-users.html#running-an-existing-test-kit).
2. Open http://localhost in a web browser.
3. Click the "Start Testing" button.
4. Confirm that a web page for the testing session opens correctly.